### PR TITLE
Fix Documentation Typo's

### DIFF
--- a/Posh365/Public/User/New-HybridMailbox.ps1
+++ b/Posh365/Public/User/New-HybridMailbox.ps1
@@ -1,8 +1,6 @@
 Function New-HybridMailbox {
     <#
     .SYNOPSIS
-        <#
-    .SYNOPSIS
     Designed to create and manage users in Hybrid Office 365 environment.
     On-Premises Exchange server is required.  
     


### PR DESCRIPTION
Removed Powershell Syntax issues on New-HybridMailbox.ps1
Items were not properly Commented. 