### PR TITLE
Add-Task Typo

### DIFF
--- a/Posh365/Public/Tasks/Add-Task.ps1
+++ b/Posh365/Public/Tasks/Add-Task.ps1
@@ -31,7 +31,7 @@ function Add-Task {
 
     .EXAMPLE
         Add-Task -TaskName "Audit Log Collection" -User "ComputerName\Logs" -RepeatInMinutes 60 -Executable "PowerShell.exe" -Argument '-ExecutionPolicy RemoteSigned -Command "Get-AuditLog -Tenant LAPCM -Path C:\Logs\ -FileName 365Log -TimeFrameInMinutes 60"'
-#>
+    #>
     [CmdletBinding()]
     Param
     (

--- a/Posh365/Public/User/New-HybridMailbox.ps1
+++ b/Posh365/Public/User/New-HybridMailbox.ps1
@@ -1,8 +1,6 @@
 Function New-HybridMailbox {
     <#
     .SYNOPSIS
-        <#
-    .SYNOPSIS
     Designed to create and manage users in Hybrid Office 365 environment.
     On-Premises Exchange server is required.  
     


### PR DESCRIPTION
Fixed a typo with Add-Task Comments.
Missed a Tab on the bottom comment. 